### PR TITLE
fix: __del__ not freeing up native resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ poetry-installer-error-*.log
 docs/_build
 .DS_Store
 dist/
+.idea/

--- a/extism/extism.py
+++ b/extism/extism.py
@@ -625,7 +625,7 @@ class Plugin:
         return parse(buf)
 
     def __del__(self):
-        if not hasattr(self, "pointer"):
+        if not hasattr(self, "plugin") or self.plugin == -1:
             return
         _lib.extism_plugin_free(self.plugin)
         self.plugin = -1

--- a/extism/extism.py
+++ b/extism/extism.py
@@ -507,7 +507,7 @@ class CompiledPlugin:
             raise Error(msg.decode())
 
     def __del__(self):
-        if not hasattr(self, "pointer") or self.pointer == -1:
+        if not hasattr(self, "pointer") or self.pointer is None or self.pointer == -1:
             return
         _lib.extism_compiled_plugin_free(self.pointer)
         self.pointer = -1

--- a/extism/extism.py
+++ b/extism/extism.py
@@ -270,10 +270,10 @@ class _ExtismFunctionMetadata:
             _lib.extism_function_set_namespace(self.pointer, f.namespace.encode())
 
     def __del__(self):
-        if not hasattr(self, "pointer"):
+        if not hasattr(self, "pointer") or self.pointer is None:
             return
-        if self.pointer is not None:
-            _lib.extism_function_free(self.pointer)
+        _lib.extism_function_free(self.pointer)
+        self.pointer = None
 
 
 def _map_arg(arg_name, xs) -> Tuple[ValType, Callable[[Any, Any], Any]]:
@@ -507,7 +507,7 @@ class CompiledPlugin:
             raise Error(msg.decode())
 
     def __del__(self):
-        if not hasattr(self, "pointer"):
+        if not hasattr(self, "pointer") or self.pointer == -1:
             return
         _lib.extism_compiled_plugin_free(self.pointer)
         self.pointer = -1

--- a/tests/test_extism.py
+++ b/tests/test_extism.py
@@ -52,11 +52,11 @@ class TestExtism(unittest.TestCase):
 
     def test_plugin_del_frees_native_resources(self):
         """Test that Plugin.__del__ properly frees native resources.
-        
+
         This tests the fix for a bug where Plugin.__del__ checked for
         'self.pointer' instead of 'self.plugin', causing extism_plugin_free
         to never be called and leading to memory leaks.
-        
+
         This also tests that __del__ can be safely called multiple times
         (via context manager exit and garbage collection) without causing
         double-free errors.
@@ -66,66 +66,80 @@ class TestExtism(unittest.TestCase):
             self.assertEqual(j["count"], 1)
             # Plugin should own the compiled plugin it created
             self.assertTrue(plugin._owns_compiled_plugin)
-        
+
         # Verify plugin was freed after exiting context
-        self.assertEqual(plugin.plugin, -1, 
-            "Expected plugin.plugin to be -1 after __del__, indicating extism_plugin_free was called")
+        self.assertEqual(
+            plugin.plugin,
+            -1,
+            "Expected plugin.plugin to be -1 after __del__, indicating extism_plugin_free was called",
+        )
         # Verify compiled plugin was also freed (since Plugin owned it)
-        self.assertIsNone(plugin.compiled_plugin,
-            "Expected compiled_plugin to be None after __del__, indicating it was also freed")
+        self.assertIsNone(
+            plugin.compiled_plugin,
+            "Expected compiled_plugin to be None after __del__, indicating it was also freed",
+        )
 
     def test_compiled_plugin_del_frees_native_resources(self):
         """Test that CompiledPlugin.__del__ properly frees native resources.
-        
+
         Unlike Plugin, CompiledPlugin has no context manager so __del__ is only
         called once by garbage collection. This also tests that __del__ can be
         safely called multiple times without causing double-free errors.
         """
         compiled = CompiledPlugin(self._manifest(), functions=[])
         # Verify pointer exists before deletion
-        self.assertTrue(hasattr(compiled, 'pointer'))
+        self.assertTrue(hasattr(compiled, "pointer"))
         self.assertNotEqual(compiled.pointer, -1)
-        
+
         # Create a plugin from compiled to ensure it works
         plugin = extism.Plugin(compiled)
         j = json.loads(plugin.call("count_vowels", "test"))
         self.assertEqual(j["count"], 1)
-        
+
         # Plugin should NOT own the compiled plugin (it was passed in)
         self.assertFalse(plugin._owns_compiled_plugin)
-        
+
         # Clean up plugin first
         plugin.__del__()
         self.assertEqual(plugin.plugin, -1)
-        
+
         # Compiled plugin should NOT have been freed by Plugin.__del__
-        self.assertNotEqual(compiled.pointer, -1,
-            "Expected compiled.pointer to NOT be -1 since Plugin didn't own it")
-        
+        self.assertNotEqual(
+            compiled.pointer,
+            -1,
+            "Expected compiled.pointer to NOT be -1 since Plugin didn't own it",
+        )
+
         # Now clean up compiled plugin manually
         compiled.__del__()
-        
+
         # Verify compiled plugin was freed
-        self.assertEqual(compiled.pointer, -1,
-            "Expected compiled.pointer to be -1 after __del__, indicating extism_compiled_plugin_free was called")
+        self.assertEqual(
+            compiled.pointer,
+            -1,
+            "Expected compiled.pointer to be -1 after __del__, indicating extism_compiled_plugin_free was called",
+        )
 
     def test_extism_function_metadata_del_frees_native_resources(self):
         """Test that _ExtismFunctionMetadata.__del__ properly frees native resources."""
+
         def test_host_fn(inp: str) -> str:
             return inp
-        
+
         func = TypeInferredFunction(None, "test_func", test_host_fn, [])
         metadata = _ExtismFunctionMetadata(func)
-        
+
         # Verify pointer exists before deletion
-        self.assertTrue(hasattr(metadata, 'pointer'))
+        self.assertTrue(hasattr(metadata, "pointer"))
         self.assertIsNotNone(metadata.pointer)
-        
+
         metadata.__del__()
-        
+
         # Verify function was freed (pointer set to None)
-        self.assertIsNone(metadata.pointer,
-            "Expected metadata.pointer to be None after __del__, indicating extism_function_free was called")
+        self.assertIsNone(
+            metadata.pointer,
+            "Expected metadata.pointer to be None after __del__, indicating extism_function_free was called",
+        )
 
     def test_errors_on_bad_manifest(self):
         self.assertRaises(


### PR DESCRIPTION
https://github.com/extism/extism/issues/890

**Summary**

  Fix memory leaks caused by __del__ methods not properly freeing native resources.
  Bug 1: `Plugin.__del__` never called `extism_plugin_free`
  The guard check used hasattr(self, "pointer") but Plugin stores the handle in self.plugin, not self.pointer. This caused the method to
  always return early, never freeing the native plugin.
  Bug 2: Double-free errors in all `__del__` methods
  When __del__ is called multiple times (e.g., via context manager __exit__ then garbage collection), the code would attempt to free
  already-freed resources, causing TypeError or segfaults.

  **Changes**

  • `Plugin.__del__`: Fix attribute check ("pointer" → "plugin") and add -1 guard
  • `CompiledPlugin.__del__`: Add -1 guard to prevent double-free
  • `_ExtismFunctionMetadata.__del__`: Add None guard and set pointer = None after freeing


  **Impact**

  This fix enables using extism in long-running services that create fresh plugin instances per request, which previously caused unbounded
  memory growth.

  **Test** plan

  • Added test_plugin_del_frees_native_resources - verifies Plugin cleanup via context manager
  • Added test_compiled_plugin_del_frees_native_resources - verifies CompiledPlugin cleanup
  • Added test_extism_function_metadata_del_frees_native_resources - verifies function metadata cleanup
  • All tests verify that __del__ can be safely called multiple times