### PR TITLE
fix: float arguments in host function parameters

### DIFF
--- a/extism/extism.py
+++ b/extism/extism.py
@@ -20,7 +20,6 @@ from extism_sys import lib as _lib, ffi as _ffi  # type: ignore
 import functools
 import pickle
 
-
 HOST_FN_REGISTRY: List[Any] = []
 
 
@@ -644,7 +643,7 @@ def _convert_value(x):
         return Val(ValType.I64, x.v.i64)
     elif x.t == 2:
         return Val(ValType.F32, x.v.f32)
-    elif x.y == 3:
+    elif x.t == 3:
         return Val(ValType.F64, x.v.f64)
     return None
 

--- a/tests/test_extism.py
+++ b/tests/test_extism.py
@@ -214,6 +214,25 @@ class TestExtism(unittest.TestCase):
         return read_test_wasm("loop.wasm")
 
 
+ExtismVal = namedtuple("ExtismVal", ["t", "v"])
+
+
+class TestConvertValue(unittest.TestCase):
+    """Tests for the _convert_value helper that converts CFFI ExtismVal structs."""
+
+    def _make_extism_val(self, t, **kwargs):
+        """Create a mock ExtismVal with type tag `t` and value fields."""
+        val_union = namedtuple("ValUnion", kwargs.keys())(**kwargs)
+        return ExtismVal(t=t, v=val_union)
+
+    def test_convert_f64_value(self):
+        x = self._make_extism_val(3, f64=3.14)
+        result = extism.extism._convert_value(x)
+        self.assertIsNotNone(result, "_convert_value returned None for F64 input")
+        self.assertEqual(result.t, extism.ValType.F64)
+        self.assertAlmostEqual(result.value, 3.14)
+
+
 def read_test_wasm(p):
     path = join(dirname(__file__), "..", "wasm", p)
     with open(path, "rb") as wasm_file:


### PR DESCRIPTION
There was a small typo in `_convert_value` which logged an error whenever a host function with float argument was called:

    Exception ignored from cffi callback <function handle_args at 0x7fee3735b480>:
    Traceback (most recent call last):
      File ".../extism/extism.py", line 908, in handle_args
        inp.append(_convert_value(inputs[i]))
      File ".../extism/extism.py", line 648, in _convert_value
        elif x.y == 3:
    AttributeError: cdata 'ExtismVal' has no field 'y'