### PR TITLE
fix: upgrade deprecated GitHub Actions to v4/v5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
       - name: Install poetry
         run: pipx install poetry
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'poetry'
@@ -40,7 +40,7 @@ jobs:
         run: |
           just docs
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build
@@ -48,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
       - name: Install poetry
         run: pipx install poetry
@@ -64,7 +64,7 @@ jobs:
           fi
           <<<"$pyproject" >pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'poetry'
@@ -74,7 +74,7 @@ jobs:
           just build
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*
@@ -83,11 +83,11 @@ jobs:
     needs: [docs, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: docs
           path: docs


### PR DESCRIPTION
## Summary
- Upgrades `actions/upload-artifact` and `actions/download-artifact` from v3 to v4 (v3 is deprecated and now fails)
- Bumps `actions/checkout` from v3 to v4 and `actions/setup-python` from v4 to v5

## Test plan
- [ ] Verify the `build.yaml` workflow runs successfully on push to main or tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)